### PR TITLE
Refactoring Mindfulness Page [1/n]

### DIFF
--- a/__tests__/mindfulness.test.tsx
+++ b/__tests__/mindfulness.test.tsx
@@ -1,42 +1,28 @@
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 import Page from '../app/main/Mindfulness'
-
+import videoList from '@/data/videos.json'; // Import video data
 
 jest.mock('next/navigation', () => jest.requireActual('next-router-mock'))
 jest.mock('../lib/zoomapi', () => jest.requireActual('../lib/fakezoomapi'));
 
 describe('Page', () => {
-  it('renders a heading and three videos', () => {
+  it('renders a heading and available meditation videos', () => {
     render(<Page />)
 
-
-    const video1 = screen.getByLabelText('youtube-video-1');
-    expect(video1).toBeInTheDocument();
-    
-    const video2 = screen.getByLabelText('youtube-video-2');
-    expect(video2).toBeInTheDocument();
-
-    const video3 = screen.getByLabelText('youtube-video-3');
-    expect(video3).toBeInTheDocument();
+    videoList.map((video, index) => {
+        expect(screen.getByLabelText(video.alt)).toBeInTheDocument();
+    });
   })
 
   it('renders three correct videos', () => {
     render(<Page />)
 
-    const youtube1ID = 'AKN_gbj8UtU'
-    const youtube2ID = 'c7IkEhKtUwI'
-    const youtube3ID = 'sG69_omRCyo'
-
-    const video1 = screen.getByLabelText('youtube-video-1');
-    expect(video1).toHaveAttribute('src', expect.stringContaining(youtube1ID));
-
-    const video2 = screen.getByLabelText('youtube-video-2');
-    expect(video2).toHaveAttribute('src', expect.stringContaining(youtube2ID));
-
-    const video3 = screen.getByLabelText('youtube-video-3');
-    expect(video3).toHaveAttribute('src', expect.stringContaining(youtube3ID));
-
+    videoList.map((video, index) => {
+    expect(screen.getByLabelText(video.alt)).toHaveAttribute(
+        'src',
+        expect.stringContaining(video.youtubeId)
+    );
+    });
   })
-
 })

--- a/app/main/Mindfulness.tsx
+++ b/app/main/Mindfulness.tsx
@@ -1,41 +1,41 @@
-// Under Review
-
 "use client";
 
-import '../css/Mindfulness.css'; // Import CSS file
+import '../css/Mindfulness.css';
+import videos from '@/data/videos.json'; // Import video meta data
 
 interface VideoPlayerProps {
+  name: string;
   videoId: string;
-  Label: string;
+  label: string;
+  alt: string;
 }
 
-const generateVideoPlayer = ({ videoId, Label }: VideoPlayerProps) => (
-  <div className="video-wrapper">
+const generateVideoPlayer = (
+    { name, videoId, label, alt }: VideoPlayerProps
+    ) => (
+  <div className="video-wrapper" key={label}>
     <iframe
       className='video'
-      title='Youtube player'
-      aria-label={Label}
+      title={name}
+      aria-label={alt}
       src={`https://www.youtube.com/embed/${videoId}`}
     ></iframe>
   </div>
 );
 
 function Mindfullness() {
-
-  const youtube1ID = 'AKN_gbj8UtU'
-  const youtube2ID = 'c7IkEhKtUwI'
-  const youtube3ID = 'sG69_omRCyo'
-  const youtube1Label = 'youtube-video-1';
-  const youtube2Label = 'youtube-video-2';
-  const youtube3Label = 'youtube-video-3';
-
   return (
     <div className="mindfulness-container">
       <h2 className="title">Mindfulness</h2>
       <div className="video-container">
-        {generateVideoPlayer({ videoId: youtube1ID, Label: youtube1Label })}
-        {generateVideoPlayer({ videoId: youtube2ID, Label: youtube2Label })}
-        {generateVideoPlayer({ videoId: youtube3ID, Label: youtube3Label })}
+        {videos.map((video, index) => 
+            generateVideoPlayer({
+                name: video.name,
+                videoId: video.youtubeId,
+                label: video.label,
+                alt: video.alt
+            })
+        )}
       </div>
     </div>
   );

--- a/data/videos.json
+++ b/data/videos.json
@@ -1,0 +1,20 @@
+[{
+    "name": "guided breathing",
+    "youtubeId": "AKN_gbj8UtU",
+    "description": "One minute guided breathing to calm your breath",
+    "alt": "One minute guided breathing meditation video, with both audio guide and on-screen text guide",
+    "label": "guided-breathing-video"
+}, {
+    "name": "guided body scan",
+    "youtubeId": "c7IkEhKtUwI",
+    "description": "3 minutes guided body scan to reconnect with your body",
+    "alt":"Three-minute guided body scan meditation video, with both audio guide and on-screen text guide.",
+    "label": "guided-body-scan-video"
+}, {
+    "name": "guided stretching",
+    "youtubeId": "sG69_omRCyo",
+    "description": "80 second guided stretching to reset your intention",
+    "alt": "80-second guided stretching meditation video, with both audio guide and on-screen text guide.",
+    "label": "guided-stretching-video"
+}]
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "canvas": "^2.11.2",
         "dotenv": "^16.3.1",
         "html2canvas": "^1.4.1",
+        "json-loader": "^0.5.7",
         "mongoose": "^8.0.3",
         "next": "^14.0.4",
         "next-auth": "^4.24.5",
@@ -46,6 +47,7 @@
         "lodash": "^4.17.21",
         "next-router-mock": "^0.9.11",
         "postcss": "^8",
+        "react-test-renderer": "^18.2.0",
         "tailwindcss": "^3",
         "typescript": "^5"
       }
@@ -10469,6 +10471,11 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
+    "node_modules/json-loader": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -13073,7 +13080,6 @@
       "version": "16.15.0",
       "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
       "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
-      "peer": true,
       "dependencies": {
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
@@ -13081,6 +13087,26 @@
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "dev": true,
+      "dependencies": {
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "canvas": "^2.11.2",
     "dotenv": "^16.3.1",
     "html2canvas": "^1.4.1",
+    "json-loader": "^0.5.7",
     "mongoose": "^8.0.3",
     "next": "^14.0.4",
     "next-auth": "^4.24.5",
@@ -48,6 +49,7 @@
     "lodash": "^4.17.21",
     "next-router-mock": "^0.9.11",
     "postcss": "^8",
+    "react-test-renderer": "^18.2.0",
     "tailwindcss": "^3",
     "typescript": "^5"
   }


### PR DESCRIPTION
Refactor the mindfulness page to reduce code redundancy and separate data from the code. This is the first of some upcoming changes to this page as I am planning to componentize elements and the entire page later.

List of changes:
1. Create data/ folder to store static data used in the app in JSON formate, and separate data from the code. It now  contains only one JSON file (videos.json) that stores the meta data for all the mindfulness videos. We will later create separate json files for other static data such as default affirmation messages and text for handwave buttons. 
2. Use `array.map` to loop over available videos and reduce code redundancy;
3. Update video label so they are more readable for screen readers as aria-labels;
4. Add `key` attribute to video player component as recommended by React warning messages (see below). I followed the instructions [here](https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key). 
<img width="813" alt="Screenshot 2024-04-16 at 7 01 39 PM" src="https://github.com/aimpowered/ZoomCompanion/assets/202047/b2f1bae9-edc3-4b41-8f31-de7ed396f4d9">

5. Update and simplify related unit tests (see `__tests__/mindfulness.test.tsx`) using `array.map` as well.
