### PR TITLE
Create new DrawBadgesApi to give a cleaner API for drawing badges

### DIFF
--- a/app/main/NameTag.tsx
+++ b/app/main/NameTag.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import Switch from '@mui/material/Switch';
-import drawNametag, { NameTagBadge, HandWaveBadge } from "@/lib/drawNametag";
+import { NameTagBadge, HandWaveBadge, drawEverythingToImage } from "@/lib/draw_badge_api";
 import debounce from 'lodash/debounce';
 import FormControlLabel from '@mui/material/FormControlLabel';
 
@@ -56,7 +56,8 @@ function NameTag({
            {visible: true, waveText: waveHands[selectedWaveHand]} :
            {visible: false};
 
-    const imageData = drawNametag(nametag, handWave);
+    // TODO: Switch this to use DrawBadgeApi
+    const imageData = drawEverythingToImage(nametag, handWave);
 
     console.log(selectedWaveHand)
     const configOptions: ConfigOptions = {

--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -8,7 +8,7 @@ import Mindfulness from "./Mindfulness";
 import Affirmation from "./Affirmation";
 import NameTag from "./NameTag";
 import { useCustomState } from './state';
-import drawNametag, { NameTagBadge, HandWaveBadge } from "@/lib/drawNametag";
+import { NameTagBadge, HandWaveBadge, drawEverythingToImage } from "@/lib/draw_badge_api";
 
 import { createFromConfig, ZoomApiWrapper } from "@/lib/zoomapi";
 import { ConfigOptions }  from "@zoom/appssdk";
@@ -45,7 +45,9 @@ function App() {
        state.selectedWaveHand !== null ?
            {visible: true, waveText: state.waveHands[state.selectedWaveHand]} :
            {visible: false};
-    const imageData = drawNametag(nametag, handWave);
+
+    // TODO: Switch this to use DrawBadgeApi
+    const imageData = drawEverythingToImage(nametag, handWave);
     
     console.log(state.selectedWaveHand)
     const configOptions: ConfigOptions = {

--- a/lib/draw_badge_api.ts
+++ b/lib/draw_badge_api.ts
@@ -1,6 +1,6 @@
-// Under Review
+import { ZoomApiWrapper }  from "@/lib/zoomapi";
 
-export interface NameTagBadge {
+export interface EnabledNameTagBadge {
   visible: boolean;
   fullName: string;
   preferredName: string;
@@ -14,9 +14,35 @@ interface EnabledHandWaveBadge {
   visible: true;
   waveText: string;
 }
+export type NameTagBadge = DisabledBadge | EnabledNameTagBadge;
 export type HandWaveBadge = DisabledBadge | EnabledHandWaveBadge;
 
-export default function drawNametag(nametag: NameTagBadge, handWave: HandWaveBadge): ImageData {
+const DISABLED_BADGE = { visible: false } as const;
+
+export class DrawBadgeApi {
+  private nametag: NameTagBadge = DISABLED_BADGE;
+  private handwave: HandWaveBadge = DISABLED_BADGE;
+
+  constructor(private zoomApiWrapper: ZoomApiWrapper) {}
+
+  private forceDrawing() {
+    const imageData = drawEverythingToImage(this.nametag, this.handwave);
+    return this.zoomApiWrapper.setVirtualForeground(imageData);
+  }
+
+  drawNameTag(nametag: NameTagBadge) {
+    this.nametag = nametag;
+    return this.forceDrawing();
+  }
+
+  drawHandWave(handwave: HandWaveBadge) {
+    this.handwave = handwave;
+    return this.forceDrawing();
+  }
+}
+
+/** @deprecated Use DrawBadgeApi instead */
+export function drawEverythingToImage(nametag: NameTagBadge, handWave: HandWaveBadge): ImageData {
   const canvas = document.createElement('canvas');
   const context = canvas.getContext('2d')!;
   canvas.width = 1600; // Width of the canvas


### PR DESCRIPTION
This requires you to have an instance of the API object (like the ZoomApiWrapper), and allows updating each badge individually, rather than all at once.

I haven't actually tested this or converted the existing usages of `drawEverythingToImage` to use this new API, but I think some of them should be simplified by not needing to keep track of the unchanged badges.  Note that we will need to get rid of all usages of `drawEverythingToImage` in order for the state to be correctly tracked by the `DrawBadgesApi` wrapper.