### PR TITLE
Refactor Hand Wave component(s).

### DIFF
--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -10,6 +10,7 @@ import Mindfulness from "./Mindfulness";
 import Affirmation from "./Affirmation";
 import { useCustomState } from './state';
 import { NameTagContent, NameTagForm } from "@/components/NameTagForm";
+import { WaveHandPicker } from "@/components/WaveHandPicker";
 import { HandWaveBadge, DrawBadgeApi } from "@/lib/draw_badge_api";
 import { createFromConfig, ZoomApiWrapper } from "@/lib/zoomapi";
 import { ConfigOptions }  from "@zoom/appssdk";
@@ -23,11 +24,18 @@ const zoomConfigOptions: ConfigOptions = {
 const zoomApi: ZoomApiWrapper = createFromConfig(zoomConfigOptions);
 const foregroundDrawer: DrawBadgeApi = new DrawBadgeApi(zoomApi);
 
+const defaultWaveHandButtons = [
+    '',
+    'I\'m not done',
+    'Question',
+    'Agree',
+    'Different Opinion',
+    'Support',
+];
 
 function App() {
  
   const { state, 
-  setSelectedWaveHand,
   setCurrentAffirmation,
   setAllAffirmations,
   } = useCustomState();
@@ -41,24 +49,18 @@ function App() {
     disclosure:"",
   });
 
-  // TODO: refactor HandWave component to maintain the selected state there
-  //       only use the callback function to redraw when the state is changed.
-  const handleWaveHandsClick = (num: number) => {
-    setSelectedWaveHand(num)
-
-    const handWave: HandWaveBadge =
-       state.selectedWaveHand !== null ?
-           {visible: true, waveText: state.waveHands[state.selectedWaveHand]} :
-           {visible: false};
-
-    foregroundDrawer.drawHandWave(handWave);
-  };
-
   //TODO: store the new nametag content into DB
   const updateNameTagContent: SubmitHandler<NameTagContent> = (data) => {
     setNameTagContent(data);
     foregroundDrawer.drawNameTag(data);
   };
+
+  const updateHandWaveBadge = (badge: HandWaveBadge) => {
+    foregroundDrawer.drawHandWave(badge);
+  };
+
+  //TODO: query and load user saved buttons;
+  const savedWaveHandButtons = defaultWaveHandButtons;
 
   return (
     <div>
@@ -68,17 +70,10 @@ function App() {
         </div>
       </div>
 
-      <div className="button-rows">
-        {state.waveHands.map((waveHand, index) => (
-          <button
-            key={index}
-            className={`wave-hand-button ${state.selectedWaveHand === index ? 'selected' : ''}`}
-            onClick={() => handleWaveHandsClick(index)}
-          >
-            {waveHand}
-          </button>
-        ))}
-      </div>
+      <WaveHandPicker
+        initialHands={savedWaveHandButtons}
+        updateHandWaveBadge={updateHandWaveBadge}
+      />
 
       <div>
         <Tabs>

--- a/app/main/state.ts
+++ b/app/main/state.ts
@@ -8,22 +8,11 @@ interface Button {
 }
 
 interface State {
-  selectedWaveHand: number | null;
-  waveHands: string[];
   selectedAffirmation: string;
   allAffirmations: Button[];
 }
 
 const initialState: State = {
-  selectedWaveHand: null,
-  waveHands: [
-    '👋',
-    '👋 I\'m not done',
-    '👋 Question',
-    '👋 Agree',
-    '👋 Different Opinion',
-    '👋 Support',
-  ],
   selectedAffirmation: 'Say what I want to say, whatever happens will help me grow',
   allAffirmations: [
     { id: 1, text: 'Say what I want to say, whatever happens will help me grow' },
@@ -36,14 +25,6 @@ const initialState: State = {
 
 export const useCustomState = () => {
   const [state, setState] = useState<State>(initialState);
-
-  const setSelectedWaveHand = (newSelectedWaveHand: number) => {
-    setState((prevState) => ({
-      ...prevState,
-      selectedWaveHand: prevState.selectedWaveHand === newSelectedWaveHand ? null : newSelectedWaveHand,
-    }));
-  };
-
 
   const setCurrentAffirmation = (newAffirmation: string) => {
     setState((prevState) => ({
@@ -61,7 +42,6 @@ export const useCustomState = () => {
 
   return {
     state,
-    setSelectedWaveHand,
     setCurrentAffirmation,
     setAllAffirmations,
   };

--- a/components/NameTagForm.tsx
+++ b/components/NameTagForm.tsx
@@ -29,62 +29,68 @@ export function NameTagForm({
   const { register, handleSubmit, control } = useForm<NameTagContent>();
 
   return (
-    <form onSubmit={handleSubmit(onNameTagContentChange)}>
-      <div>
-        <label>Full Name</label>
-        <input
-          className="text-input"
-          defaultValue={content.fullName}
-          {...register("fullName", { required: true })}
-        />
+    <div className="nametag-container">
+      <div className="header">
+        <h2 className="title">Name Tag</h2>
       </div>
-      <div>
-        <label>Preferred Name</label>
-        <input
-          className="text-input"
-          defaultValue={content.preferredName}
-          {...register("preferredName")}
-        />
-      </div>
-      <div>
-        <label>Pronouns</label>
-        <select
-          className="select-input"
-          defaultValue={content.pronouns}
-          {...register("pronouns")}
-        >
-          <option value="">Select Pronouns</option>
-          <option value="He/Him">He/Him</option>
-          <option value="She/Her">She/Her</option>
-          <option value="They/Them">They/Them</option>
-          <option value="other">Other</option>
-        </select>
-      </div>
-      <div>
-        <label>Self Disclosure</label>
-        <input
-          className="text-input"
-          defaultValue={content.disclosure}
-          {...register("disclosure")}
-        />
-      </div>
-      <div>
-        <Controller
-          control={control}
-          name="visible"
-          defaultValue={content.visible}
-          render={({ field: { onChange, value } }) => (
-            <FormControlLabel
-              control={
-                <Checkbox checked={value} onChange={onChange} />
-              }
-              label="Display Name Tag"
-              labelPlacement="end"
-            />
-          )}
-        />
-      </div>
-      <input type="submit" />
-    </form>
+
+      <form onSubmit={handleSubmit(onNameTagContentChange)}>
+        <div>
+          <label>Full Name</label>
+          <input
+            className="text-input"
+            defaultValue={content.fullName}
+            {...register("fullName", { required: true })}
+          />
+        </div>
+        <div>
+          <label>Preferred Name</label>
+          <input
+            className="text-input"
+            defaultValue={content.preferredName}
+            {...register("preferredName")}
+          />
+        </div>
+        <div>
+          <label>Pronouns</label>
+          <select
+            className="select-input"
+            defaultValue={content.pronouns}
+            {...register("pronouns")}
+          >
+            <option value="">Select Pronouns</option>
+            <option value="He/Him">He/Him</option>
+            <option value="She/Her">She/Her</option>
+            <option value="They/Them">They/Them</option>
+            <option value="other">Other</option>
+          </select>
+        </div>
+        <div>
+          <label>Self Disclosure</label>
+          <input
+            className="text-input"
+            defaultValue={content.disclosure}
+            {...register("disclosure")}
+          />
+        </div>
+        <div>
+          <Controller
+            control={control}
+            name="visible"
+            defaultValue={content.visible}
+            render={({ field: { onChange, value } }) => (
+              <FormControlLabel
+                control={
+                  <Checkbox checked={value} onChange={onChange} />
+                }
+                label="Display Name Tag"
+                labelPlacement="end"
+              />
+            )}
+          />
+        </div>
+        <input type="submit" />
+      </form>
+    </div>
   );
 }

--- a/components/WaveHandButton.tsx
+++ b/components/WaveHandButton.tsx
@@ -5,11 +5,17 @@ interface HandButtonProps {
   onClick: () => void;
   text: string;
 }
-export function WaveHandButton({ selected, onClick, text }: HandButtonProps) {
-  return <button
-    className={`wave-hand-button ${selected ? 'selected' : ''}`}
-    onClick={onClick}
-  >
-    {text}
-  </button>;
+export function WaveHandButton({
+  selected,
+  onClick,
+  text
+}: HandButtonProps) {
+  return (
+    <button
+      className={`wave-hand-button ${selected ? 'selected' : ''}`}
+      onClick={onClick}
+    >
+      {text}
+    </button>
+  );
 }

--- a/components/WaveHandPicker.tsx
+++ b/components/WaveHandPicker.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { useState } from 'react';
+import { WaveHandButton } from '@/components/WaveHandButton';
+import {HandWaveBadge } from '@/lib/draw_badge_api';
+
+const waveHandEmoji = '👋';
+
+interface WaveHandPickerProps {
+  initialHands: string[];
+  updateHandWaveBadge: (badge: HandWaveBadge) => void;
+}
+
+export function WaveHandPicker({
+  initialHands,
+  updateHandWaveBadge,
+}: WaveHandPickerProps) {
+
+  const [selectedButtonId, setSelectedButtonId] = useState(-1);
+
+  const appendEmoji = (text: string) => {
+    return waveHandEmoji + ' ' + text;
+  }
+
+  const clickButton = (id: number, text: string) => {
+    if (selectedButtonId == id) {
+      setSelectedButtonId(-1); // unselect a button
+      // hide HandWaveBadge
+      updateHandWaveBadge({visible: false});
+    } else { 
+      setSelectedButtonId(id);
+      // draw selected HandWaveBadge
+      updateHandWaveBadge({
+        visible: true,
+        waveText: appendEmoji(text),
+      })
+    }
+  };
+
+  return (
+    <div className="button-rows">
+      {initialHands.map((text, index) => (
+        <WaveHandButton
+          key={text}
+          selected={ index == selectedButtonId }
+          onClick={() => clickButton(index, text)}
+          text={appendEmoji(text)}
+        />
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
1. Add a WaveHandPicker Component to keep track of which handwave button is selected;
2. When a button is selected or unselect, the WaveHandPicker will create a new HandWaveBadge that is to be re-rendered by the root (App) component.
3. Get rid of the handwave button states at the App level, we only need to keep track of the selectedButtonId inside the WaveHandPicker component.
4. also included a small change to NameTagForm that adds a title.

This PR also fixed current bug that the clicked button and displayed badge are out-of-sync. See screenshot below:

<img width="1695" alt="Screenshot 2024-04-26 at 10 45 51 PM" src="https://github.com/aimpowered/ZoomCompanion/assets/202047/75ad8946-345c-492f-9c2d-bb20d821668d">
