### PR TITLE
Remove 'handleWaveHandsClick' from app/main/page.tsx

### DIFF
--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -59,19 +59,6 @@ function App() {
 
   const [nameTagIsLoaded, setNameTagIsLoaded] = useState(false);
 
-  // TODO: refactor HandWave component to maintain the selected state there
-  //       only use the callback function to redraw when the state is changed.
-  const handleWaveHandsClick = (num: number) => {
-    setSelectedWaveHand(num)
-
-    const handWave: HandWaveBadge =
-       state.selectedWaveHand !== null ?
-           {visible: true, waveText: state.waveHands[state.selectedWaveHand]} :
-           {visible: false};
-
-    foregroundDrawer.drawHandWave(handWave);
-  };
-
   const updateNameTagContent: SubmitHandler<NameTagContent> = (data) => {
     setNameTagContent(data);
     foregroundDrawer.drawNameTag(data);


### PR DESCRIPTION
Accidentally re-added this function after merging 'store-user-nametag-in-db' with 'main', and this broke things... Removing this function again.

This should hopefully fix the deployment errors that resulted after I merged 'store-user-nametag-in-db' with 'main'.