### PR TITLE
Sending chat messages for full self disclosure using the Recall.ai API and a Zoom bot

### DIFF
--- a/__tests__/nameTagForm.test.tsx
+++ b/__tests__/nameTagForm.test.tsx
@@ -29,10 +29,14 @@ describe('NameTagForm', () => {
     expect(screen.getByText('Preferred Name')).toBeInTheDocument();
     expect(screen.getAllByText('Pronouns')[0]).toBeInTheDocument();
     expect(screen.getByText('Self Disclosure')).toBeInTheDocument();
-    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+
+    let checkboxes = screen.getAllByRole('checkbox');
+    checkboxes.forEach(checkbox => {
+      expect(checkbox).toBeInTheDocument();
+    })
   })
 
-  it('verifies that the nametag display checkbox can be checked', async () => {
+  it('verifies that the nametag display and send disclosure message checkboxes can be checked', async () => {
 
     render(
       <NameTagForm
@@ -41,15 +45,21 @@ describe('NameTagForm', () => {
       />
     );
 
-    const element = screen.getByLabelText('Display Name Tag');
-    expect(element).toBeInTheDocument();
+    const displayNameTagCheckboxElement = screen.getByLabelText('Display Name Tag');
+    expect(displayNameTagCheckboxElement).toBeInTheDocument();
 
-    let checkboxInput = screen.getByRole('checkbox')
+    const sendDisclosureMessageCheckboxElement = screen.getByLabelText('Send Disclosure Message');
+    expect(sendDisclosureMessageCheckboxElement).toBeInTheDocument();
 
-    expect(checkboxInput).toBe(element);
+    let checkboxes = screen.getAllByRole('checkbox');
+
+    expect(checkboxes).toContain(displayNameTagCheckboxElement);
+    expect(checkboxes).toContain(sendDisclosureMessageCheckboxElement);
     
-    expect(checkboxInput).not.toBeChecked();
-    await userEvent.click(checkboxInput);
-    expect(checkboxInput).toBeChecked();
+    checkboxes.forEach(async (checkboxElement) => {
+      expect(checkboxElement).not.toBeChecked();
+      await userEvent.click(checkboxElement);
+      expect(checkboxElement).toBeChecked();
+    });
   });
 })

--- a/app/api/chatMessages/route.ts
+++ b/app/api/chatMessages/route.ts
@@ -1,0 +1,143 @@
+// import https from 'https';
+import startDB from "@/lib/db";
+import UserModel from "@/models/userModel";
+import { NextResponse } from "next/server";
+
+const ZOOM_CHATBOT_TIMEOUT = process.env.ZOOM_CHATBOT_TIMEOUT || 180;
+const LIBORATE_BOT_NAME = process.env.LIBORATE_BOT_NAME || "LibOrate Bot";
+const RECALL_AI_API_BASE_URL = process.env.RECALL_AI_API_BASE_URL || "https://us-west-2.recall.ai/api/v1";
+
+/**
+ * POST request to send chat message to a meeting chat that the user is currently in
+ */
+
+interface SendChatMessageRequest {
+    userEmail: string;
+    meetingJoinUrl: string;
+    meetingUUID: string;
+    message: string;
+    userName?: string;
+}
+
+type SendChatMessageResponse = NextResponse<{ success?: boolean; error?: string }>;
+
+export const POST = async (req: Request): Promise<SendChatMessageResponse> => {
+    const body = (await req.json()) as SendChatMessageRequest;
+
+    const errorHandlingForServerErrors = function(error: unknown) {
+      console.error(error);
+  
+      return NextResponse.json({
+        success: false,
+        error: error
+      }, { status: 500 });
+    };
+
+    await startDB();
+
+
+    /* STEP 1: Check if there is an active bot for the user and if the meeting UUID of the bot
+       is the same as the meeting UUID passed in. */
+
+    let activeBotId = null;
+    let activeBotStatus = null;
+
+    // Get the user
+    const user = await UserModel.findOne({ email: body.userEmail });
+    if (!user) {
+      return NextResponse.json({
+        success: false,
+        error: `User with email '${body.userEmail}' does not exist.`
+      },
+      { status: 400 });
+    }
+
+    // user.botId == the bot ID of the most recent bot created for the user, if it exists
+    if (user.botId) {
+      // Retrieve the bot (using the Recall.ai API)
+      const retrieveBotResponse = await fetch(`${RECALL_AI_API_BASE_URL}/bot/${user.botId}/`, { 
+        method: "GET",
+        headers: {
+          "Authorization": `Token ${process.env.RECALL_API_KEY}`,
+          "accept": "application/json"
+        }
+      }).catch(errorHandlingForServerErrors);
+
+      const retrieveBotResponseJson = await retrieveBotResponse.json().catch(errorHandlingForServerErrors);
+
+      // Check the meeting URL of the bot to see if it matches the meeting URL that was passed in
+      if (retrieveBotResponseJson.meeting_metadata) {
+        console.log(`retrieveBotResponseJson.meeting_metadata.zoom_meeting_uuid = ${retrieveBotResponseJson.meeting_metadata.zoom_meeting_uuid}`);
+      }
+      console.log(`body.meetingUUID = ${body.meetingUUID}`);
+      if (retrieveBotResponseJson.meeting_metadata && retrieveBotResponseJson.meeting_metadata.zoom_meeting_uuid === body.meetingUUID) {
+        // Retrieve the bot's current status
+        activeBotStatus = retrieveBotResponseJson.status_changes[retrieveBotResponseJson.status_changes.length - 1].code;
+        
+        // Set the activeBotId
+        activeBotId = user.botId;
+      }
+    }
+
+
+    /* STEP 2: If there is NOT an active bot for the user in the current meeting, then create
+       one and use it to send the new disclosure message to meeting participants. */
+
+    if (activeBotStatus === null || activeBotStatus === "done" || activeBotStatus === "fatal") {
+      const createBotResponse = await fetch(`${RECALL_AI_API_BASE_URL}/bot/`, { 
+        method: "POST",
+        headers: {
+          "Authorization": `Token ${process.env.RECALL_API_KEY}`,
+          "accept": "application/json",
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({
+          "meeting_url": body.meetingJoinUrl,
+          "bot_name": (body.userName && body.userName !== "") ? `${LIBORATE_BOT_NAME} (for ${body.userName})` : `${LIBORATE_BOT_NAME}`,
+          "automatic_leave": {
+            "waiting_room_timeout": ZOOM_CHATBOT_TIMEOUT,
+            "noone_joined_timeout": ZOOM_CHATBOT_TIMEOUT,
+            "in_call_not_recording_timeout": ZOOM_CHATBOT_TIMEOUT
+          },
+          "recording_mode_options": {
+            "start_recording_on": "manual"
+          },
+          "chat": {
+            "on_bot_join": {
+              "send_to": "everyone",
+              "message": body.message
+            }
+          }
+        })
+      }).catch(errorHandlingForServerErrors);
+
+      const createBotResponseJson = await createBotResponse.json().catch(errorHandlingForServerErrors);
+
+      // Update the bot ID in the user's DB entry
+      await UserModel.updateOne({ email: body.userEmail}, {
+        botId: createBotResponseJson.id
+      });
+    }
+
+
+    /* STEP 3: If there is an active bot for the user and the bot is not currently in the
+       waiting room, then use it to send the new disclosure message to meeting participants. */
+
+    else if (activeBotStatus !== "in_waiting_room")
+    {
+      await fetch(`${RECALL_AI_API_BASE_URL}/bot/${activeBotId}/send_chat_message/`, { 
+        method: "POST",
+        headers: {
+          "Authorization": `Token ${process.env.RECALL_API_KEY}`,
+          "accept": "application/json",
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({
+          "message": body.message
+        })
+      }).catch(errorHandlingForServerErrors);
+    }
+
+
+    return NextResponse.json({ success: true }, { status: 200 });
+};

--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -21,6 +21,8 @@ const zoomConfigOptions: ConfigOptions = {
   capabilities: [
     "setVirtualForeground",
     "removeVirtualForeground",
+    "getMeetingJoinUrl",
+    "getMeetingUUID"
   ]
 };
 const zoomApi: ZoomApiWrapper = createFromConfig(zoomConfigOptions);
@@ -55,13 +57,19 @@ function App() {
     preferredName:"",
     pronouns:"",
     disclosure:"",
+    fullDisclosureMessage:"",
+    sendDisclosureMessage:false
   });
 
   const [nameTagIsLoaded, setNameTagIsLoaded] = useState(false);
 
   const updateNameTagContent: SubmitHandler<NameTagContent> = (data) => {
     setNameTagContent(data);
+
     foregroundDrawer.drawNameTag(data);
+    if (data.sendDisclosureMessage) {
+      foregroundDrawer.sendDisclosureChatMessage(data.fullDisclosureMessage, data.fullName);
+    }
 
     // Update nametag in DB
     updateNameTagInDB(data);

--- a/components/NameTagForm.tsx
+++ b/components/NameTagForm.tsx
@@ -14,6 +14,8 @@ export interface NameTagContent {
   preferredName: string;
   pronouns: string;
   disclosure: string;
+  fullDisclosureMessage: string;
+  sendDisclosureMessage: boolean;
 }
 
 interface NameTagProps {
@@ -73,6 +75,15 @@ export function NameTagForm({
             {...register("disclosure")}
           />
         </div>
+        <div>
+          <label>Disclosure Message</label>
+          <textarea
+            className="text-input"
+            rows={6}
+            defaultValue={content.fullDisclosureMessage}
+            {...register("fullDisclosureMessage")}
+          />
+        </div>
         <div className="form-container">
           <div className="controller-container">
             <Controller
@@ -90,9 +101,26 @@ export function NameTagForm({
                 />
               )}
             />
-            </div>
-          <input type="submit" className="submit-btn" />
+          </div>
+          <div className="controller-container">
+            <Controller
+              control={control}
+              name="sendDisclosureMessage"
+              defaultValue={content.sendDisclosureMessage}
+              render={({ field: { onChange, value } }) => (
+                <FormControlLabel
+                  control={
+                    <Checkbox checked={value} onChange={onChange} />
+                  }
+                  label="Send Disclosure Message"
+                  labelPlacement="start"
+                  className="label-styling" 
+                />
+              )}
+            />
+          </div>
         </div>
+        <input type="submit" className="submit-btn" />
       </form>
     </div>
   );

--- a/lib/draw_badge_api.ts
+++ b/lib/draw_badge_api.ts
@@ -39,6 +39,10 @@ export class DrawBadgeApi {
     this.handwave = handwave;
     return this.forceDrawing();
   }
+
+  sendDisclosureChatMessage(disclosureMessage: string, userName?: string) {
+    this.zoomApiWrapper.sendChatMessage(disclosureMessage, userName);
+  }
 }
 
 // TODO: make sure the imageData scale and resize correctly based on window size.

--- a/lib/fakezoomapi.ts
+++ b/lib/fakezoomapi.ts
@@ -4,6 +4,7 @@ import { GeneralMessageResponse }  from "@zoom/appssdk";
 class FakeZoomApi implements ZoomApiWrapper {
   async setVirtualForeground(): Promise<GeneralMessageResponse> { return null as unknown as GeneralMessageResponse; }
   async removeVirtualForeground(): Promise<GeneralMessageResponse> { return null as unknown as GeneralMessageResponse; }
+  async sendChatMessage(): Promise<boolean> { return null as unknown as boolean; }
 }
 export type {ZoomApiWrapper};
 

--- a/lib/zoomapi.ts
+++ b/lib/zoomapi.ts
@@ -1,8 +1,10 @@
 import zoomSdk, {ConfigOptions, ConfigResponse, GeneralMessageResponse }  from "@zoom/appssdk";
+import { getSession } from 'next-auth/react';
 
 export interface ZoomApiWrapper {
   setVirtualForeground(imageData: ImageData): Promise<GeneralMessageResponse>;
   removeVirtualForeground(): Promise<GeneralMessageResponse>;
+  sendChatMessage(chatMessage: string, userName?: string): Promise<boolean>;
 }
 
 export function createFromConfig(options: ConfigOptions) {
@@ -31,4 +33,34 @@ class ZoomApiImpl implements ZoomApiWrapper {
     return zoomSdk.removeVirtualForeground();
   }
 
+  async sendChatMessage(chatMessage: string, userName?: string): Promise<boolean> {
+    await this.initialize();
+    
+    const getMeetingJoinUrlResponse = await zoomSdk.getMeetingJoinUrl();
+    const getMeetingUUIDResponse = await zoomSdk.getMeetingUUID();
+
+    const session = await getSession();
+
+    if (session && session.user) {
+      await fetch("/api/chatMessages", { 
+        method: "POST",
+        body: JSON.stringify({
+            userEmail: session.user.email,
+            meetingJoinUrl: getMeetingJoinUrlResponse.joinUrl,
+            meetingUUID: getMeetingUUIDResponse.meetingUUID,
+            message: chatMessage,
+            userName: (typeof userName !== 'undefined') ? userName : null
+        }),
+      }).catch((error) => {
+          console.error(`[sendChatMessage] Error sending chat message: ${error}`);
+          return false;
+      });
+
+      return true;
+    }
+
+    else {
+      return false;
+    }
+  }
 }

--- a/models/userModel.ts
+++ b/models/userModel.ts
@@ -10,6 +10,7 @@ interface UserDocument extends Document {
     password: string;
     role: "admin" | "user";
     nameTag: NameTagContent;
+    botId: string;
 }
 
 interface Methods {
@@ -27,8 +28,11 @@ const userSchema = new Schema<UserDocument, {}, Methods>({
         preferredName: { type: String },
         pronouns: { type: String },
         disclosure: { type: String },
-        visible: { type: Boolean }
-    }
+        visible: { type: Boolean },
+        fullDisclosureMessage: { type: String },
+        sendDisclosureMessage: { type: Boolean }
+    },
+    botId: { type: String }
 });
 
 //Hash the password before saving


### PR DESCRIPTION
Note that the following environment variables need to be set for this to work:

- `RECALL_API_KEY`: The API key for Recall.ai
- `RECALL_AI_API_BASE_URL`: The base URL for the Recall.ai API. If this is not set, then the default value is "https://us-west-2.recall.ai/api/v1".
- `ZOOM_CHATBOT_TIMEOUT`: A timeout for how long the Zoom bot will stay in the meeting after it is created (in seconds). If this is not set, then the default value is 180 seconds, or 3 minutes. This is to minimize the cost of using the Recall.ai API (as every second a bot spends in a meeting costs some money).

Also need to modify the settings of the Zoom app so that:

- The Zoom Meeting SDK is enabled, and
- The following API functions in the Zoom Apps SDK are enabled: `getMeetingJoinUrl` and `getMeetingUUID`.