### PR TITLE
Remove "full name" field from the name tag.

### DIFF
--- a/__tests__/nameTagForm.test.tsx
+++ b/__tests__/nameTagForm.test.tsx
@@ -6,8 +6,7 @@ import { NameTagForm } from '@/components/NameTagForm';
 
 const currentNameTag = {
   visible: false,
-  fullName: "Test User",
-  preferredName: "",
+  preferredName: "Test User",
   pronouns: "",
   disclosure: "",
 };
@@ -25,7 +24,6 @@ describe('NameTagForm', () => {
         onNameTagContentChange={updateNameTagContent}
       />
     );
-    expect(screen.getByText('Full Name')).toBeInTheDocument();
     expect(screen.getByText('Preferred Name')).toBeInTheDocument();
     expect(screen.getAllByText('Pronouns')[0]).toBeInTheDocument();
     expect(screen.getByText('Self Disclosure')).toBeInTheDocument();

--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -45,7 +45,6 @@ const defaultAffirmations = [
 function App() {
   const [nameTagContent, setNameTagContent] = useState<NameTagContent>({
     visible:false,
-    fullName:"",
     preferredName:"",
     pronouns:"",
     disclosure:"",

--- a/components/NameTagForm.tsx
+++ b/components/NameTagForm.tsx
@@ -10,7 +10,6 @@ import '@/app/css/NameTag.css';
 // TODO: deduplicate this with EnabledNameTagBadge
 export interface NameTagContent {
   visible: boolean;
-  fullName: string;
   preferredName: string;
   pronouns: string;
   disclosure: string;
@@ -34,19 +33,11 @@ export function NameTagForm({
 
       <form onSubmit={handleSubmit(onNameTagContentChange)}>
         <div>
-          <label>Full Name</label>
-          <input
-            className="text-input"
-            defaultValue={content.fullName}
-            {...register("fullName", { required: true })}
-          />
-        </div>
-        <div>
           <label>Preferred Name</label>
           <input
             className="text-input"
             defaultValue={content.preferredName}
-            {...register("preferredName")}
+            {...register("preferredName", { required: true })}
           />
         </div>
         <div>

--- a/lib/draw_badge_api.ts
+++ b/lib/draw_badge_api.ts
@@ -2,7 +2,6 @@ import { ZoomApiWrapper }  from "@/lib/zoomapi";
 
 export interface EnabledNameTagBadge {
   visible: boolean;
-  fullName: string;
   preferredName: string;
   pronouns: string;
   disclosure: string;
@@ -70,11 +69,7 @@ function drawEverythingToImage(nametag: NameTagBadge, handWave: HandWaveBadge): 
     context.fillStyle = 'black';
 
 
-    if (nametag.preferredName) {
-      context.fillText(nametag.fullName + ' (' + nametag.preferredName + ')', 800, 600 + 0 * 50);
-    } else {
-      context.fillText(nametag.fullName, 800, 600 + 0 * 50);
-    }
+    context.fillText(nametag.preferredName, 800, 600 + 0 * 50);
     context.font = '30px Arial';
     context.fillText(nametag.pronouns, 800, 600 + 1 * 50);
 

--- a/models/userModel.ts
+++ b/models/userModel.ts
@@ -23,7 +23,6 @@ const userSchema = new Schema<UserDocument, {}, Methods>({
     password: { type: String, required: true},
     role: { type: String, enum: ["admin", "user"], default: "user" },
     nameTag: {
-        fullName: { type: String },
         preferredName: { type: String },
         pronouns: { type: String },
         disclosure: { type: String },


### PR DESCRIPTION
"Full Name" field is redundant with existing Zoom user name. Remove it to only keep "preferred name" in the name tag and display. 

New behavior:

<img width="1635" alt="Screenshot 2024-07-30 at 9 30 59 PM" src="https://github.com/user-attachments/assets/c2fd27de-42e2-47ad-b314-37d78b12b50b">
