### PR TITLE
Fix the location of nametag on user video

### DIFF
--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -18,8 +18,8 @@ import Divider from '@mui/material/Divider';
 
 const zoomConfigOptions: ConfigOptions = {
   capabilities: [
-    "setVirtualForeground",
-    "removeVirtualForeground",
+    'setVirtualForeground',
+    'onMyMediaChange',
   ]
 };
 const zoomApi: ZoomApiWrapper = createFromConfig(zoomConfigOptions);

--- a/lib/fakezoomapi.ts
+++ b/lib/fakezoomapi.ts
@@ -1,9 +1,7 @@
-import { ZoomApiWrapper } from './zoomapi';
-import { GeneralMessageResponse }  from "@zoom/appssdk";
+import { DrawImageCallback, ZoomApiWrapper } from './zoomapi';
 
 class FakeZoomApi implements ZoomApiWrapper {
-  async setVirtualForeground(): Promise<GeneralMessageResponse> { return null as unknown as GeneralMessageResponse; }
-  async removeVirtualForeground(): Promise<GeneralMessageResponse> { return null as unknown as GeneralMessageResponse; }
+  async setDrawImageCallback(cb: DrawImageCallback): Promise<void> {}
 }
 export type {ZoomApiWrapper};
 

--- a/lib/zoomapi.ts
+++ b/lib/zoomapi.ts
@@ -1,8 +1,16 @@
-import zoomSdk, {ConfigOptions, ConfigResponse, GeneralMessageResponse }  from "@zoom/appssdk";
+import zoomSdk, {ConfigOptions, ConfigResponse, VideoMedia }  from "@zoom/appssdk";
+
+export interface VideoDimensions {
+   width: number;
+   height: number;
+}
+
+export interface DrawImageCallback {
+    (v: VideoDimensions): ImageData;
+}
 
 export interface ZoomApiWrapper {
-  setVirtualForeground(imageData: ImageData): Promise<GeneralMessageResponse>;
-  removeVirtualForeground(): Promise<GeneralMessageResponse>;
+  setDrawImageCallback(cb: DrawImageCallback): Promise<void>;
 }
 
 export function createFromConfig(options: ConfigOptions) {
@@ -11,24 +19,31 @@ export function createFromConfig(options: ConfigOptions) {
 
 class ZoomApiImpl implements ZoomApiWrapper {
   private configResponse: null|Promise<ConfigResponse> = null;
+  private drawImageCallback: null|DrawImageCallback = null;
   constructor(private configOptions: ConfigOptions) {}
 
   initialize() {
     if (this.configResponse == null) {
       this.configResponse = zoomSdk.config(this.configOptions);
+      zoomSdk.onMyMediaChange((event) => {
+        if (event.media && 'video' in event.media) {
+            this.drawForeground(event.media);
+        }
+      });
     }
     return this.configResponse;
-
   }
 
-  async setVirtualForeground(imageData: ImageData): Promise<GeneralMessageResponse> {
-    await this.initialize();
+  async setDrawImageCallback(cb: DrawImageCallback):Promise<void> {
+    this.drawImageCallback = cb;
+    const configResponse = await this.initialize();
+    await this.drawForeground(configResponse.media);
+  }
+
+  private async drawForeground({video: {width, height} = {}}: VideoMedia = {}) {
+    if (this.drawImageCallback == null) return;
+    if (width == null || height == null) return;
+    const imageData = this.drawImageCallback({width, height});
     return zoomSdk.setVirtualForeground({imageData});
   }
-
-  async removeVirtualForeground(): Promise<GeneralMessageResponse> {
-    await this.initialize();
-    return zoomSdk.removeVirtualForeground();
-  }
-
 }


### PR DESCRIPTION
This PR takes the video size information from Zoom API config responses as well as onMyMediaChange event to make sure the nametag always display at the bottom right corner of user's video. It enables:
1) fixed location of nametag (not floating around when video is turned off/on);
2) relative sizing of the nametag to user's video;
3) relative resolution of the nametag, adaptive to user video feed resolution;

**After state:**
1. Low resolution camera (mirrored view)
<img width="1504" alt="Screenshot 2024-08-07 at 4 36 53 PM" src="https://github.com/user-attachments/assets/e18b6df3-aaf3-4237-93ea-7b3b90563595">

2. High resolution camera (mirrored view)
<img width="1511" alt="Screenshot 2024-08-07 at 4 48 46 PM" src="https://github.com/user-attachments/assets/9979809a-b046-459e-affd-852cff5d7648">
